### PR TITLE
Skip optional parameters where the value is null in custom values

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -267,6 +267,10 @@ function processParams(code, op, path, options) {
   op.getParameters().forEach(function (param, ndx, arr) {
     var customValue = lookupCustomValue(param.name, param.in, code, op.method,
         path.path, options)
+    // Skip optional parameter with specifically nulled custom value
+    if (customValue === null && (! param.required)) {
+      return
+    }
 
     if (param.in === 'body') {
       params.body = customValue !== undefined ? customValue : param.getSample()
@@ -291,6 +295,10 @@ function processParams(code, op, path, options) {
   path.getParameters().forEach(function (param, ndx, arr) {
     var customValue = lookupCustomValue(param.name, param.in, code, op.method,
         path.path, options)
+    // Skip optional parameter with specifically nulled custom value
+    if (customValue === null && (! param.required)) {
+      return
+    }
     params.path = pathify(params.path, param, customValue)
   })
 


### PR DESCRIPTION
Fix #13 