### PR TITLE
Custom values can now override fields in the request header

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -348,20 +348,6 @@ function processHeaders(responseCode, op, path, top, options) {
   var headers = {};
   var levels = [path.path, op.method, responseCode]
 
-  // check custom request values for any desired headers; cascading merge
-  if (options.customValues) {
-    var curr = options.customValues
-
-    var ndx = 0
-    do {
-      if (curr['header'] !== undefined) {
-        headers = merge2(curr['header'], headers)
-      }
-
-      curr = curr[levels[ndx]]
-    } while (ndx++ < levels.length && curr !== undefined)
-  }
-
   // handle consumes
   if (options.consumes) { // a specific content-type was targeted
     if (op.definitionFullyResolved.consumes) {
@@ -403,6 +389,20 @@ function processHeaders(responseCode, op, path, top, options) {
     headers['Accept'] = op.definitionFullyResolved.produces[0];
   } else if (top.produces.length > 0) {
     headers['Accept'] = top.produces[0];
+  }
+
+  // check custom request values for any desired headers; cascading merge
+  if (options.customValues) {
+    var curr = options.customValues
+
+    var ndx = 0
+    do {
+      if (curr['header'] !== undefined) {
+        headers = merge2(curr['header'], headers)
+      }
+
+      curr = curr[levels[ndx]]
+    } while (ndx++ < levels.length && curr !== undefined)
   }
 
   return headers


### PR DESCRIPTION
fixed #17 by changing the order of the header parameter generation so that the custom values override the previous defined values if neccecarry