### PR TITLE
Escape single quotes in response descriptions

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -215,7 +215,7 @@ function processTransactions(api, parentOp, parentPath, topLevel, options) {
 
     transactions.push({
       'testLevelDescription': util.format('should respond %s for "%s"',
-          res.statusCode, replaceNewlines(res.description)),
+          res.statusCode, escapeSingleQuotes(replaceNewlines(res.description))),
       'scheme': topLevel.scheme,
       'host': topLevel.host,
       'path': (topLevel.basePath + params.path),
@@ -367,7 +367,7 @@ function lookupCustomQueryValue(code, op, path, options) {
       if (curr.query !== undefined) {
         val = curr.query
       }
-    
+
       curr = curr[levels[ndx]];
     } while (ndx++ < levels.length && curr)
   }
@@ -563,4 +563,16 @@ function determineQueryType(param) {
  */
 function replaceNewlines(str) {
   return str.replace(/\r?\n|\r/g, " ")
+}
+
+/**
+ * Used to escape single quotes in each response.description
+ * @function escapeSingleQuotes
+ * @memberof processing
+ * @instance
+ * @param {string} str string to escape single quotes
+ * @return {string}
+ */
+function escapeSingleQuotes(str) {
+  return str.replace(/'/g, "\\'")
 }


### PR DESCRIPTION
If response descriptions have a single quote - such as "don't" - then the description of the "should have" test for this produces an invalid JavaScript string.  This escapes these single quotes where they occur in response descriptions.

Written by someone completely unused to writing JavaScript and who doesn't use Node, so I'm sorry if it's not idiomatic.

Signed-off-by: Paul Wayper <paulway@redhat.com>