### PR TITLE
Add an option to generate only a specific set of operations for a par…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,20 @@ Then use in your command line
 
   Options:
 
-    -h, --help                             output usage information
-    --host <host>                          target hostname to use in test generation
-    -p, --paths <paths>                    comma separated list of paths to generate tests for
-    -e, --samples                          generate sample response bodies rather than schema, if applicable
-    -s, --spec <spec>                      path to the target OpenAPI/Swagger spec document to consume
-    -w, --writeTo <writeTo>                directory to write the generated tests to file
-    -c, --consumes <consumes>              consumes/content-type to use in request when applicable to the API resource
-    -o, --produces <produces>              produces/accept to use in request when applicable to the API resource
-    -u, --customValues <customValues>      custom request values to be used in generation; takes precedent over a customValuesFile
-    --customValuesFile <customValuesFile>  path to JSON file with custom request values to be used in generation
-    -m, --scheme <scheme>                  which scheme to use if multiple are present in spec
-    -t --templates <templateDir>           path to direcotry of custom templates
-    -S, --status-codes <statusCodes>       comma separated list of status codes to explicity generate tests for
+    -h, --help                                      output usage information
+    --host <host>                                   target hostname to use in test generation
+    -p, --paths <paths>                             comma separated list of paths to generate tests for
+    -e, --samples                                   generate sample response bodies rather than schema, if applicable
+    -s, --spec <spec>                               path to the target OpenAPI/Swagger spec document to consume
+    -w, --writeTo <writeTo>                         directory to write the generated tests to file
+    -c, --consumes <consumes>                       consumes/content-type to use in request when applicable to the API resource
+    -o, --produces <produces>                       produces/accept to use in request when applicable to the API resource
+    -u, --customValues <customValues>               custom request values to be used in generation; takes precedent over a customValuesFile
+    --customValuesFile <customValuesFile>           path to JSON file with custom request values to be used in generation
+    -m, --scheme <scheme>                           which scheme to use if multiple are present in spec
+    -t --templates <templateDir>                    path to direcotry of custom templates
+    -S, --status-codes <statusCodes>                comma separated list of status codes to explicity generate tests for
+    -P, --pathsWithOperations <pathsWithOperations> comma separated list of paths with respective operations to generate tests for, where path and operations are separated by '_' delimiter
 
 > oatts generate -s ./path/to/openapi.yaml -w ./output/dir
 > ls ./output/dir
@@ -135,6 +136,7 @@ The following options can be passed to the generation function, some/all are exp
 | `scheme` | `--scheme -m` | `spec.schemes[0]` | `false` | Override for multiple scheme present in a spec |
 | `templates` | `--templates -t` | `'./templates'` | `false` | Path to directory containing custom templates |
 | `statusCodes` |`--status-codes -S` | `operation.responses` | `false` | comma separated list of status codes to explicity generate tests for |
+| `pathsWithOperations` | `--pathsWithOperations -P` | n/a | `false` | comma separated list of paths with respective operations to generate tests for, where path and operations are separated by '_' delimiter |
 | `jsonRefs` | | n/a | `false` | *(See [JsonRefs~JsonRefsOptions](https://github.com/whitlockjc/json-refs/blob/master/docs/API.md#module_JsonRefs..JsonRefsOptions))* |
 | `customFormats` | | n/a | `false` | The key/value pair of custom formats *(The keys are the format name and the values are async functions.  See [ZSchema Custom Formats](https://github.com/zaggino/z-schema#register-a-custom-format))* |
 | `customFormatGenerators` | | n/a | `false` | The key/value pair of custom format generators *(The keys are the format name and the values are functions.  See [json-schema-mocker Custom Format](https://github.com/json-schema-faker/json-schema-faker#custom-formats))* |

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -50,6 +50,8 @@ cli.command('generate')
     .option('-S, --status-codes <statusCodes>',
         'comma separated list of status codes to explicity generate tests for',
         util.sep)
+    .option('-P, --pathsWithOperations <pathsWithOperations>',
+        'comma separated list of paths with respective operations to generate tests for, where path and operations are separated by "_" delimiter', util.sep)
     .action(function (options) {
       options.error = util.optionError;
       if (!options.spec) {

--- a/lib/process.js
+++ b/lib/process.js
@@ -90,12 +90,17 @@ function processPaths(api, topLevel, options) {
   var targetPaths = [];
 
   if (options.paths !== undefined) {
-    options.paths.forEach(function (path, ndx, arr) {
-      targetPaths.push(api.getPath(path))
-    })
-  } else {
-    targetPaths = api.getPaths();
+    options.paths.forEach(function(path, ndx, arr) {
+      targetPaths.push(api.getPath(path));
+    });
   }
+  if (options.pathsWithOperations !== undefined) {
+    options.pathsWithOperations.forEach(function(pathWithOperations, ndx, arr) {
+      var path = pathWithOperations.split('_')[0];
+      targetPaths.push(api.getPath(path));
+    });
+  }
+  targetPaths = targetPaths.length === 0 ? api.getPaths() : targetPaths;
 
   if (options.statusCodes !== undefined) {
     var tempPaths = [];
@@ -150,9 +155,28 @@ function processPaths(api, topLevel, options) {
  */
 function processOperations(api, parentPath, topLevel, options) {
   var ops = []
-  parentPath.getOperations().forEach(function (op, ndx, arr) {
-    var transactions = processTransactions(api, op, parentPath, topLevel,
-        options)
+  var allowedOps = [];
+
+  if (options.pathsWithOperations !== undefined) {
+    options.pathsWithOperations.forEach(function(pathWithOperations, ndx, arr) {
+      var pathWithOps = pathWithOperations.split('_');
+      if (pathWithOps[0] === parentPath.path) {
+        allowedOps = pathWithOps.slice(1);
+      }
+    });
+  }
+
+  parentPath.getOperations().forEach(function(op, ndx, arr) {
+    var transactions = [];
+    if (allowedOps.length === 0 || allowedOps.indexOf(op.method) > -1) {
+      transactions = processTransactions(
+        api,
+        op,
+        parentPath,
+        topLevel,
+        options
+      );
+    }
     if (transactions.length !== 0) {
       ops.push({
         'operationLevelDescription': 'tests for ' + op.method,

--- a/test/process/test.js
+++ b/test/process/test.js
@@ -399,5 +399,73 @@ describe('process', function () {
         done(err)
       }
     })
+
+    it("should process '/pet/{petId}' with -p option to contain all operations and process '/pet' with -P option to contain only POST operation", function(done) {
+      try {
+        var data = process(api, { pathsWithOperations: ["/pet_post"], paths: ["/pet/{petId}"] });
+        expect(data).to.not.be.null;
+        expect(data.scheme).to.equal("http");
+        expect(data.consumes).to.be.empty;
+        expect(data.tests.length).to.equal(
+          2,
+          "returned tests set was expected to have 2 item, but it had " +
+            data.tests.length
+        );
+        expect(data.tests[0].operations.length).to.equal(
+          3,
+          "/pet/{petId} path was expected to have 3 operation, but it had " +
+          data.tests[0].operations.length
+        );
+        expect(data.tests[1].operations.length).to.equal(
+          1,
+          "/pet path was expected to have 1 operation, but it had " +
+          data.tests[1].operations.length
+        );
+        expect(data.tests[1].operations[0].operationLevelDescription).to.equal(
+          'tests for post',
+          "/pet path was expected to have post operation, but it had " +
+          data.tests[1].operations[0].operationLevelDescription
+        );
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+    it("should process '/pet/{petId}' & '/pet' and contain only PUT and DELETE operataions respectively", function(done) {
+      try {
+        var data = process(api, { pathsWithOperations: ["/pet_put","/pet/{petId}_delete"] });
+        expect(data).to.not.be.null;
+        expect(data.scheme).to.equal("http");
+        expect(data.consumes).to.be.empty;
+        expect(data.tests.length).to.equal(
+          2,
+          "returned tests set was expected to have 2 item, but it had " +
+            data.tests.length
+        );
+        expect(data.tests[0].operations.length).to.equal(
+          1,
+          "/pet path was expected to have 1 operation, but it had " +
+          data.tests[0].operations.length
+        );
+        expect(data.tests[0].operations[0].operationLevelDescription).to.equal(
+          'tests for put',
+          "/pet path was expected to have put operation, but it had " +
+          data.tests[0].operations[0].operationLevelDescription
+        );
+        expect(data.tests[1].operations.length).to.equal(
+          1,
+          "/pet/{petId} path was expected to have 1 operation, but it had " +
+          data.tests[1].operations.length
+        );
+        expect(data.tests[1].operations[0].operationLevelDescription).to.equal(
+          'tests for delete',
+          "/pet/{petId} path was expected to have delete operation, but it had " +
+          data.tests[1].operations[0].operationLevelDescription
+        );
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
   })
 })


### PR DESCRIPTION
…ticular path

Add new CLI option -P --pathsWithOperations which would take a comma-separated list of paths with respective operations using '_' delimiter.
Example: -P '/pet_put_post,/pet/{petId}_delete' will generate only PUT and POST operations for '/pet' path and DELETE operation for '/pet/{petId}' path.