### PR TITLE
feat(OAS 3-requestBody): Support for OAS 3 requestBody as customValue

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -217,6 +217,11 @@ function processTransactions(api, parentOp, parentPath, topLevel, options) {
     for (let index = 0; index < count; index++) {
       var params = processParams(res.statusCode, parentOp, parentPath, options, index)
       var expected = processResponse(res, parentOp.method, parentPath.path, options, index)
+      var requestBody = processRequestBody(res.pathToDefinition, options)
+
+      if (requestBody && Object.keys(params.body).length === 0 ){
+        params.body = requestBody
+      }
 
       var hasValue = options.samples
       if (expected.custom) {
@@ -594,4 +599,25 @@ function replaceNewlines(str) {
  */
 function escapeSingleQuotes(str) {
   return str.replace(/'/g, "\\'")
+}
+
+/**
+ * 
+ * @param {} pathToDefinition Definition array with [ path, defPath, method, response, code]
+ * @param {*} options 
+ * @returns 
+ */
+function processRequestBody( pathToDefinition, options ){
+  const [ path, defPath, method, response, code ] = pathToDefinition
+  let requestBody = null
+
+  if (['post', 'patch', 'put'].includes(method)){
+    if ( options.customValues 
+      && options.customValues[defPath] 
+      && options.customValues[defPath][method]
+      && options.customValues[defPath][method][code]){
+      requestBody = options.customValues[defPath][method][code]['requestBody']
+    }
+  }
+  return requestBody
 }


### PR DESCRIPTION
Allows the specification of a requestBody as a customValue for [POST, INT, PUT] methods. 
For example:
```
  "/user": {
    "post": {
      "200": {
          "requestBody": {
              "name": "John Doe",
              "age": 15
          },
          "response": {
              "name": "John Doe"
          }
      }
    }
  }
```
I know that parsing parameters relays on the sway implementation. But "requestBody" from OAS 3 is still not supported and for OAS-3.X is not a parameter anymore. 
What do you think about having this here?


